### PR TITLE
enable checkProperties for prevent-abbreviations linting rule

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -167,6 +167,10 @@ module.exports = {
             element: true,
           }
         },
+        whitelist: {
+          attr: true
+        },
+        checkProperties: true,
       },
     ],
     "unicorn/throw-new-error": "error",


### PR DESCRIPTION
allow `attr` as a valid property since this is used in HTML