### PR TITLE
react, vue - add additional `install-peerdeps` instructions

### DIFF
--- a/configs/react/README.md
+++ b/configs/react/README.md
@@ -10,9 +10,10 @@ The configuration has a number of peer dependencies that must be installed.
 npm i --dev @mediamonks/eslint-config-react
 ```
 
-**Note for `yarn` users**: `yarn` does not install peer dependencies by default, this can be supplemented with `install-peerdeps`.
+**Note for `yarn` users**: `yarn` does not install peer dependencies by default, this can be supplemented with `install-peerdeps`. Because this config depends on [@mediamonks/eslint-config-base](../base/README.md), you will first have to install its peer dependencies.
 
 ```bash
+npx install-peerdeps --dev --only-peers @mediamonks/eslint-config-base
 npx install-peerdeps --dev @mediamonks/eslint-config-react
 ```
 

--- a/configs/vue/README.md
+++ b/configs/vue/README.md
@@ -10,9 +10,10 @@ The configuration has a number of peer dependencies that must be installed.
 npm i --dev @mediamonks/eslint-config-vue
 ```
 
-**Note for `yarn` users**: `yarn` does not install peer dependencies by default, this can be supplemented with `install-peerdeps`.
+**Note for `yarn` users**: `yarn` does not install peer dependencies by default, this can be supplemented with `install-peerdeps`. Because this config depends on [@mediamonks/eslint-config-base](../base/README.md), you will first have to install its peer dependencies.
 
 ```bash
+npx install-peerdeps --dev --only-peers @mediamonks/eslint-config-base
 npx install-peerdeps --dev @mediamonks/eslint-config-vue
 ```
 


### PR DESCRIPTION
`install-peerdeps` does not install nested peer dependencies. As our
`react` and `vue` configs have a peer dependency for the `base` config,
`install-peerdeps` for just the peer dependencies of `react` or `vue`
configs would not work. However running `install-peerdeps` beforehand
for the base config installs the correct peer dependencies.