### PR TITLE
base: disable `unicorn/prevent-abbreviations` for imports

### DIFF
--- a/configs/base/index.js
+++ b/configs/base/index.js
@@ -161,6 +161,8 @@ module.exports = {
     "unicorn/prevent-abbreviations": [
       "error",
       {
+        checkDefaultAndNamespaceImports : false,
+        checkShorthandImports: false,
         replacements: {
           ref: false,
           refs: false,


### PR DESCRIPTION
fixes #17