### PR TITLE
Feature: remove prettier plugin

### DIFF
--- a/configs/base/README.md
+++ b/configs/base/README.md
@@ -29,3 +29,7 @@ Now you can add `@mediamonks/eslint-config-base` to your `.eslintrc`. Adding `pa
 }
 
 ```
+
+### Formatting & Prettier
+
+This eslint configuration purposely had its formatting rules disabled. We encourage to use [prettier](https://prettier.io/) for formatting using the [`@mediamonks/prettier-config`](https://github.com/mediamonks/prettier-config).

--- a/configs/base/index.js
+++ b/configs/base/index.js
@@ -3,8 +3,8 @@ module.exports = {
     "airbnb-base",
     "plugin:jsx-a11y/recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended",
     "plugin:import/typescript",
+    "prettier", // required to disable eslint rules that affect prettier formatting
   ],
   plugins: ["import", "unicorn", "babel"],
   parser: "@typescript-eslint/parser",
@@ -123,7 +123,7 @@ module.exports = {
           "**/*.spec.ts",
           "**/*.test.tsx",
           "**/*.spec.tsx",
-          "**/test-utils/**/*.ts"
+          "**/test-utils/**/*.ts",
         ],
       },
     ],
@@ -171,7 +171,7 @@ module.exports = {
     "unicorn/prevent-abbreviations": [
       "error",
       {
-        checkDefaultAndNamespaceImports : false,
+        checkDefaultAndNamespaceImports: false,
         checkShorthandImports: false,
         replacements: {
           ref: false,

--- a/configs/base/package.json
+++ b/configs/base/package.json
@@ -8,8 +8,7 @@
     "Standards",
     "eslint",
     "JavaScript",
-    "TypeScript",
-    "Prettier"
+    "TypeScript"
   ],
   "author": "MediaMonks",
   "bugs": {

--- a/configs/base/package.json
+++ b/configs/base/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-html": "^6.2.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^38.0.1"
   },
   "publishConfig": {

--- a/configs/react/README.md
+++ b/configs/react/README.md
@@ -30,3 +30,7 @@ Now you can add `@mediamonks/eslint-config-react` to your `.eslintrc`. Adding `p
 }
 
 ```
+
+### Formatting & Prettier
+
+This eslint configuration purposely had its formatting rules disabled. We encourage to use [prettier](https://prettier.io/) for formatting using the [`@mediamonks/prettier-config`](https://github.com/mediamonks/prettier-config).

--- a/configs/react/package.json
+++ b/configs/react/package.json
@@ -9,7 +9,6 @@
     "eslint",
     "JavaScript",
     "TypeScript",
-    "Prettier",
     "react",
     "jsx"
   ],

--- a/configs/vue/README.md
+++ b/configs/vue/README.md
@@ -30,3 +30,7 @@ Now you can add `@mediamonks/eslint-config-vue` to your `.eslintrc`. Adding `par
 }
 
 ```
+
+### Formatting & Prettier
+
+This eslint configuration purposely had its formatting rules disabled. We encourage to use [prettier](https://prettier.io/) for formatting using the [`@mediamonks/prettier-config`](https://github.com/mediamonks/prettier-config).

--- a/configs/vue/package.json
+++ b/configs/vue/package.json
@@ -9,7 +9,6 @@
     "eslint",
     "JavaScript",
     "TypeScript",
-    "Prettier",
     "vue"
   ],
   "author": "MediaMonks",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "eslint-plugin-html": "^6.2.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-unicorn": "^38.0.1",
         "prettier": "^2.0.0",
         "typescript": "^4.5.2"
@@ -1696,27 +1695,6 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
-      "peer": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
@@ -2010,12 +1988,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "peer": true
-    },
-    "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "peer": true
     },
     "node_modules/fast-glob": {
@@ -3103,18 +3075,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "peer": true,
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/progress": {
@@ -5100,15 +5060,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
-      "peer": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-plugin-react": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
@@ -5300,12 +5251,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "peer": true
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "peer": true
     },
     "fast-glob": {
@@ -6100,15 +6045,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
       "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "peer": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "peer": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "progress": {
       "version": "2.0.3",


### PR DESCRIPTION
Initially we were planning on having prettier configured within this eslint configuration, and eslint handling formatting. However, after some discussion in https://github.com/mediamonks/eslint-config/pull/25, the decision has been made to separate formatting (prettier) from eslint, and require users to run both.

This PR removes the prettier plugin and adds a section to each README explaining how to include our new prettier configuration https://github.com/mediamonks/prettier-config.