### PR TITLE
Make rule `import/order` more strict

### DIFF
--- a/configs/base/index.js
+++ b/configs/base/index.js
@@ -111,7 +111,10 @@ module.exports = {
       },
     ],
     "import/no-unresolved": "error",
-    "import/order": ["error", { groups: ["external", "builtin", ["sibling", "parent"]] }],
+    "import/order": ["error", {
+      groups: ["builtin", "external", "internal", "parent", "sibling", "index", "object"],
+      warnOnUnassignedImports: true,
+    }],
     "import/prefer-default-export": "off",
     "import/no-extraneous-dependencies": [
       "error",


### PR DESCRIPTION
This enforces that the scss import is always at the end of the imports