### PR TITLE
Restrict the usage of `window.outerWidth`

### DIFF
--- a/configs/base/index.js
+++ b/configs/base/index.js
@@ -137,6 +137,8 @@ module.exports = {
       "error",
       { object: "document", property: "querySelector" },
       { object: "document", property: "querySelectorAll" },
+      { object: "window", property: "outerWidth" },
+      { object: "window", property: "outerHeight" },
     ],
     "no-undef": "off", // TypeScript already handles this
     "no-underscore-dangle": "error",

--- a/configs/base/index.js
+++ b/configs/base/index.js
@@ -137,7 +137,7 @@ module.exports = {
       "error",
       { object: "document", property: "querySelector" },
       { object: "document", property: "querySelectorAll" },
-      { object: "window", property: "outerWidth" },
+      { object: "window", property: "outerWidth", message: "Did you mean to use `innerWidth` ?" },
       { object: "window", property: "outerHeight" },
     ],
     "no-undef": "off", // TypeScript already handles this

--- a/configs/base/index.js
+++ b/configs/base/index.js
@@ -138,7 +138,7 @@ module.exports = {
       { object: "document", property: "querySelector" },
       { object: "document", property: "querySelectorAll" },
       { object: "window", property: "outerWidth", message: "Did you mean to use `innerWidth` ?" },
-      { object: "window", property: "outerHeight" },
+      { object: "window", property: "outerHeight", message: "Did you mean to use `innerHeight` ?" },
     ],
     "no-undef": "off", // TypeScript already handles this
     "no-underscore-dangle": "error",


### PR DESCRIPTION
and `window.outerHeight`. As they are usually confused with
`window.innerWidth` or `window.innerHeight`