### PR TITLE
[Feature] expand naming convention

### DIFF
--- a/configs/base/index.js
+++ b/configs/base/index.js
@@ -84,6 +84,11 @@ module.exports = {
         format: ["strictCamelCase", "UPPER_CASE"],
       },
       {
+        selector: "variable",
+        modifiers: ["exported"],
+        format: ["strictCamelCase", "StrictPascalCase", "UPPER_CASE"]
+      },
+      {
         selector: "enumMember",
         format: ["StrictPascalCase"],
       },

--- a/configs/base/index.js
+++ b/configs/base/index.js
@@ -71,6 +71,11 @@ module.exports = {
         trailingUnderscore: "forbid",
       },
       {
+        selector: "objectLiteralProperty",
+        modifiers: ["requiresQuotes"],
+        format: null
+      },
+      {
         selector: "typeLike",
         format: ["StrictPascalCase"],
       },


### PR DESCRIPTION
> permit exported variables to be `StrictPascalCase`

Our component names across frameworks are in `PascalCase`, and as we generally write one component per file, they are immediately exported. So it makes sence IMO, to permit exported variables to be `StrictPascalCase`.

> permit any format for object literal properties

The current setup makes it really annoying to code HTML element attributes, which we often do in Muban.

_example:_
```js
attr: {
  'aria-expanded': ...,
  'aria-disabled': ...,
}
```

I think it is completely reasonable to permit any format for object literal properties. As the only time where we will actually use them is when the keys of the object in question are not known i.e. `Record<string, ...>`. So in cases like above in Muban, or handling API data - all cases that we can't control.