### PR TITLE
Disable arithmetic operators in `no-mixed-operators` rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -97,7 +97,19 @@ module.exports = {
     'no-lonely-if': 'error',
     'no-loop-func': 'error',
     'no-magic-numbers': 'off',
-    'no-mixed-operators': 'error',
+    'no-mixed-operators': [
+      'error',
+      {
+        groups: [
+          // ["+", "-", "*", "/", "%", "**"], This is disabled because of prettier
+          ['&', '|', '^', '~', '<<', '>>', '>>>'],
+          ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+          ['&&', '||'],
+          ['in', 'instanceof'],
+        ],
+        allowSamePrecedence: true,
+      },
+    ],
     'no-multi-assign': 'error',
     'no-multi-str': 'error',
     'no-negated-condition': 'error',

--- a/packages/test-eslint-config/prettier.js
+++ b/packages/test-eslint-config/prettier.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-redeclare,no-var,no-unused-vars,no-inline-comments */
+const a = 1;
+const b = 2;
+const c = 3;
+const d = 4;
+
+var foo = a || b || c;
+var foo = a && b && c;
+var foo = (a && b < 0) || c > 0 || d + 1 === 0;
+var foo = a && (b < 0 || c > 0 || d + 1 === 0);
+var foo = a + b * c; // <--- this is how prettier formats it, conflicts with no-mixed-operators arithmetic option
+var foo = (a + b) * c;


### PR DESCRIPTION
This is disabled because it conflicts with how prettier formats our code.

fixes #65