### PR TITLE
Loosening a bit the rules for better DX

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -12,7 +12,7 @@ module.exports = {
      * Possible Problems
      */
     'array-callback-return': 'error',
-    'no-await-in-loop': 'error',
+    // 'no-await-in-loop': 'error',
     'no-constant-binary-expression': 'error',
     'no-constructor-return': 'error',
     'no-duplicate-imports': 'error',
@@ -30,20 +30,15 @@ module.exports = {
      * Suggestions
      */
     'accessor-pairs': 'error',
-    'arrow-body-style': ['error', 'as-needed'],
+    // 'arrow-body-style': ['error', 'as-needed'],
     // 'block-scoped-var': 'error',
-    camelcase: [
-      'error',
-      {
-        properties: 'always',
-      },
-    ],
+    camelcase: ['error', { properties: 'always' }],
     // 'capitalized-comments': 'error',
-    'class-methods-use-this': 'error',
+    // 'class-methods-use-this': 'error',
     // 'complexity': 'error',
     'consistent-return': 'error',
     // 'consistent-this': 'error',
-    curly: 'error',
+    // curly: 'error',
     'default-case': 'error',
     'default-case-last': 'error',
     'default-param-last': 'error',
@@ -85,10 +80,10 @@ module.exports = {
     'no-extra-bind': 'error',
     // 'no-extra-label': 'error',
     'no-floating-decimal': 'error',
-    'no-implicit-coercion': 'error',
+    // 'no-implicit-coercion': 'error',
     'no-implicit-globals': 'error',
     'no-implied-eval': 'error',
-    'no-inline-comments': 'error',
+    // 'no-inline-comments': 'error',
     'no-invalid-this': 'error',
     'no-iterator': 'error',
     // 'no-label-var': 'error',
@@ -110,10 +105,10 @@ module.exports = {
         allowSamePrecedence: true,
       },
     ],
-    'no-multi-assign': 'error',
+    // 'no-multi-assign': 'error',
     'no-multi-str': 'error',
-    'no-negated-condition': 'error',
-    'no-nested-ternary': 'error',
+    // 'no-negated-condition': 'error',
+    // 'no-nested-ternary': 'error',
     'no-new': 'error',
     'no-new-func': 'error',
     'no-new-object': 'error',
@@ -136,13 +131,7 @@ module.exports = {
     'no-throw-literal': 'error',
     'no-undef-init': 'error',
     // 'no-undefined': 'error',
-    'no-underscore-dangle': [
-      'error',
-      {
-        enforceInMethodNames: true,
-        enforceInClassFields: true,
-      },
-    ],
+    'no-underscore-dangle': ['error', { enforceInMethodNames: true, enforceInClassFields: true }],
     'no-unneeded-ternary': 'error',
     'no-unused-expressions': 'error',
     'no-useless-call': 'error',
@@ -159,9 +148,9 @@ module.exports = {
     'operator-assignment': 'error',
     'prefer-arrow-callback': 'error',
     'prefer-const': 'error',
-    'prefer-destructuring': 'error',
+    // 'prefer-destructuring': 'error',
     'prefer-exponentiation-operator': 'error',
-    'prefer-named-capture-group': 'error',
+    // 'prefer-named-capture-group': 'error',
     'prefer-numeric-literals': 'error',
     'prefer-object-has-own': 'error',
     'prefer-object-spread': 'error',
@@ -252,34 +241,30 @@ module.exports = {
     /**
      * Unicorn
      */
+    'unicorn/consistent-function-scoping': 'off',
     'unicorn/custom-error-definition': 'error',
-    'unicorn/filename-case': [
-      'error',
-      {
-        cases: {
-          camelCase: true,
-          pascalCase: true,
-        },
-      },
-    ],
+    'unicorn/filename-case': ['error', { cases: { camelCase: true, pascalCase: true } }],
+    'unicorn/no-array-for-each': 'off',
+    'unicorn/no-array-reduce': 'off',
     // 'unicorn/no-keyword-prefix': 'error',
+    'unicorn/no-negated-condition': 'off',
     'unicorn/no-null': 'off',
     'unicorn/no-unsafe-regex': 'error',
     'unicorn/no-unused-properties': 'error',
+    'unicorn/prefer-array-find': 'off',
     'unicorn/prefer-at': 'error',
     'unicorn/prefer-event-target': 'error',
     'unicorn/prefer-json-parse-buffer': 'error',
-    'unicorn/prefer-string-replace-all': 'error',
+    'unicorn/prefer-module': 'off',
+    'unicorn/prefer-number-properties': 'off',
+    'unicorn/prefer-string-replace-all': 'off',
+    'unicorn/prefer-string-slice': 'off',
+    'unicorn/prevent-abbreviations': 'off',
     'unicorn/require-post-message-target-origin': 'error',
     // 'unicorn/string-content': 'error',
     'unicorn/numeric-separators-style': [
       'error',
-      {
-        onlyIfContainsSeparator: true,
-        number: {
-          onlyIfContainsSeparator: false,
-        },
-      },
+      { onlyIfContainsSeparator: true, number: { onlyIfContainsSeparator: false } },
     ],
 
     /**
@@ -321,15 +306,7 @@ module.exports = {
     // 'import/no-named-export': 'error',
     // 'import/no-namespace': 'error',
     // 'import/no-unassigned-import': 'error',
-    'import/order': [
-      'error',
-      {
-        alphabetize: {
-          order: 'asc',
-        },
-        'newlines-between': 'never',
-      },
-    ],
+    'import/order': ['error', { alphabetize: { order: 'asc' }, 'newlines-between': 'never' }],
     // 'import/prefer-default-export': 'error',
   },
 };


### PR DESCRIPTION
Here is an initial list of rules we should consider disabling for better DX.

**no-await-in-loop:** sometimes we want/need do to things sequentially (like loading things in a specific order) and can leverage a for loop to do so. This rule introduces unnecessary verbosity.  

**arrow-body-style:** this is just a style preference with no real impact in the result. I prefer to use the arrow function syntax when the body is a single expression, but I don't think it's worth enforcing it.

**class-methods-use-this:** this rule introduces unnecessary congnitive complexity. Sometimes the code is cleaner and easier to read when all methods are defined in the class, even if they don't use `this`.

**curly:** this rule is too strict, and one of the most annoying. One liners can keep the code cleaner and easier to read.

**no-implicit-coercion:** introduces unnecessary verbosity

**no-inline-comments:** sometimes inline comments are useful to explain a specific line of code specially when the comment is really short.

**no-multi-assign:** again, single liners can keep the code cleaner and faster to read.

**no-negated-condition:** this rule is one of the top contenders for the most annoying rule. Sometimes it's easier to read a negated condition than the positive one.

**no-nested-ternary:** introduces unnecessary verbosity

**prefer-destructuring:** dot notation can be useful to determine where some value is coming from. It can also avoid variable name collisions. Also, forcing destructuring often introduces unnecessary verbosity.

**prefer-named-capture-group:** regex is already hard to read, this rule makes it even harder.

**unicorn/consistent-function-scoping:** introduces unnecessary verbosity

**unicorn/no-array-for-each:** super annoying. introduces unnecessary verbosity

**unicorn/no-array-reduce:** super annoying. introduces unnecessary verbosity

**unicorn/prefer-array-find:** this forbids this elegant way of filtering out nullish values: `array.filter(Boolean)`

**unicorn/prefer-module:** this breaks inline require(), which can be really useful in some cases.  

**unicorn/prefer-number-properties:** introduces unnecessary verbosity

**unicorn/prefer-string-replace-all:** introduces unnecessary verbosity

**unicorn/prefer-string-slice:** substr and substring work in slightly different ways, and sometimes we need to use one or the other.

**unicorn/prevent-abbreviations:** another huge contender for the most annoying rule.